### PR TITLE
Reload connection pool when connection with Postgres is lost

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 psycopg2==2.7.1
+pgcopy


### PR DESCRIPTION
As the connection pool is created during the initialization, when the connection to the PostgreSQL server is lost, Addok is not able to setup a new connection pool. Thus, you must restart Addok to get your service back.

This PR intends to fix this behavior by checking if the connection is lost every time you request a connection from the pool. If it's the case, it will create a new pool and pick a connection from it.